### PR TITLE
Fixed functionality for adding multiple Testrail IDs to test header for Vitest reporter

### DIFF
--- a/src/reporters/caller-vitest.js
+++ b/src/reporters/caller-vitest.js
@@ -148,17 +148,22 @@ class CallerVitest extends BaseClass {
                 "\t",
               )}\n`
             : "PASS";
-        const data = {
-          case_id: +case_id,
-          status_id,
-          comment,
-          elapsed: this.utils._formatTime(element[1].duration) || "",
-          defects: "",
-          version: "",
-          // add screenshot as attachment
-          attachments: [element[2].failScreenshotPath] || [],
-        };
-        testResults.push(data);
+
+        case_id.forEach((item) => 
+        {
+            const data = 
+            {
+              case_id: item,
+              status_id,
+              comment,
+              elapsed: this.utils._formatTime(element[1].duration) || "",
+              defects: "",
+              version: "",
+              // add screenshot as attachment
+              attachments: [element[2].failScreenshotPath] || [],
+            };
+          testResults.push(data);
+        })
       }
     });
   }
@@ -180,9 +185,13 @@ class CallerVitest extends BaseClass {
       if (!element.name.match(/[@C][?\d]{1,8}$/gm) && element.tasks) {
         this.processStartList(element.tasks);
       } else {
-        const case_id = this.utils._formatTitle(element.name);
-        if (case_id != null) {
-          case_ids.push(parseInt(case_id[1]));
+        const case_id = this.utils._extractCaseIdsFromTitle(element.name);
+        if (case_id != null) 
+        {
+          case_id.forEach((item) => 
+          {             
+            case_ids.push(item) 
+          })
         } else if (self.testrailConfigs.create_missing_cases) {
           this.missingCasesTitles.push(element.name);
         }
@@ -201,7 +210,7 @@ class CallerVitest extends BaseClass {
           testResults.push(data);
         } else {
           if (case_id) {
-            startList[element.id] = +case_id[1];
+            startList[element.id] = case_id.map((id) => +id);
           }
         }
       }

--- a/test/vitest/package.json
+++ b/test/vitest/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "gTests": "vitest ./g_my_tests.spec.js --config vitest.config.with-reporter.ts",
     "newRun": "vitest ./newRun.spec.js --config vitest.config.with-reporter.ts",
     "e2eSmokeTests": "vitest ./tests/e2eSmokeTests.spec.js --config vitest.config.no-reporter.ts"
   },

--- a/test/vitest/tests/child_tests/g_my_tests.spec.js
+++ b/test/vitest/tests/child_tests/g_my_tests.spec.js
@@ -1,0 +1,23 @@
+import { describe, test, expect } from "vitest";
+
+const testsData = [
+  { id: 1, name: "EX test title 1", result: true },
+  { id: 2, name: "EX test title 2", result: true },
+  { id: 3, name: "EX test title 3", result: true },
+  { id: 4, name: "EX test title 4", result: false },
+  { id: 5, name: "EX test title 5", result: false },
+  { id: 6, name: "EX test title 6", result: false },
+  { id: 7, name: "EX test title 7", result: true },
+];
+describe("Example Tests", () => {
+  testsData.forEach((data) => {
+    test.skipIf(data.status)(`${data.name} @C${data.id}`, () => {
+      expect.soft(data.result).toBe(true);
+    });
+  });
+
+  test('One test cover multiple in testRail @C8 @C9 @C10 @C11 @C12 @C13 @C14', async () => 
+  {
+    expect.soft(true).toEqual(true)
+  })
+});


### PR DESCRIPTION
Added support for multiple TestRail case IDs in a single test title for the Vitest reporter.